### PR TITLE
Add Autograding Github Workflow

### DIFF
--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -28,7 +28,6 @@ jobs:
           path: student_code
 
       # Get Grading Repo
-      # TODO remove ref configuration once it is merged.
       - name: Master Repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Master Repo
         uses: actions/checkout@v3
         with:
-          ref: version-bump
           token: ${{secrets.F22_3155_PAT}}
           repository: csci3155/pppl-labdev
           path: master_code

--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -1,0 +1,58 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Autograding
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Get Student Repo
+      - name: Student Repo
+        uses: actions/checkout@v3
+        with:
+          path: student_code
+
+      # Get Grading Repo
+      # TODO remove ref configuration once it is merged.
+      - name: Master Repo
+        uses: actions/checkout@v3
+        with:
+          ref: version-bump
+          token: ${{secrets.F22_3155_PAT}}
+          repository: csci3155/pppl-labdev
+          path: master_code
+
+      # Prep grading repo
+      - name: Prep Grading
+        run: ./grade.sh prepare . "jsy.grader.Lab1Grading"
+        working-directory: ./master_code
+
+      # Grade the current
+      - name: Grade current 
+        run: ./gradelab1.sh ../student_code . ../ 2>&1 | tee ../grading.log
+        working-directory: ./master_code
+
+      # Display the score
+      - name: Display Score
+        run: tail -n 1 grading.log
+
+      - name: Upload Grading Log
+        uses: actions/upload-artifact@v3
+        with:
+          name: grading.log
+          path: grading.log

--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Prep grading repo
       - name: Prep Grading
-        run: ./grade.sh prepare . "jsy.grader.Lab1Grading"
+        run: ./gradepreplab1.sh prepare .
         working-directory: ./master_code
 
       # Grade the current

--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Prep grading repo
       - name: Prep Grading
-        run: ./gradepreplab1.sh prepare .
+        run: ./gradepreplab1.sh .
         working-directory: ./master_code
 
       # Grade the current


### PR DESCRIPTION
The workflow clones the private grading repository and uses it to grade the student repo. 
The output of the grading is dumped to `grading.log` and the file is uploaded as an artifact.

This grading.log can be used as a grading report. 

The grade can be extracted from the report manually or programmatically and used further.

This gets copied over from this `template repository` to the student repository when used with Github Classroom.

The sanity can be seen in the Github Workflows of this Repo/Pull Request.