### PR TITLE
Update Lab1 Workflows for Timeout and Efficient Actions usage

### DIFF
--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Grade current 
         run: ./gradelab1.sh ../student_code . ../ 2>&1 | tee ../grading.log
         working-directory: ./master_code
+        timeout-minutes: 10
 
       # Display the score
       - name: Display Score

--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -5,9 +5,9 @@ name: Autograding
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
-  
+
   pull_request:
-    branches: [ "feedback" ]
+    branches: [ "feedback", "main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/autograding.yml
+++ b/.github/workflows/autograding.yml
@@ -5,10 +5,9 @@ name: Autograding
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
-  push:
-    branches: [ "main", "master" ]
+  
   pull_request:
-    branches: [ "main", "master" ]
+    branches: [ "feedback" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/sbt-test.yml
+++ b/.github/workflows/sbt-test.yml
@@ -4,10 +4,9 @@ name: sbt test
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
-  
+  # Triggers the workflow on pull request events but only for the "main" branch
   pull_request:
-    branches: [ "feedback" ]
+    branches: [ "feedback", "main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/sbt-test.yml
+++ b/.github/workflows/sbt-test.yml
@@ -38,3 +38,4 @@ jobs:
       - name: Run sbt test
         run: sbt test
         working-directory: ./student_code
+        timeout-minutes: 10

--- a/.github/workflows/sbt-test.yml
+++ b/.github/workflows/sbt-test.yml
@@ -5,13 +5,13 @@ name: sbt test
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
-  push:
-    branches: [ "main", "master" ]
+  
   pull_request:
-    branches: [ "main", "master" ]
+    branches: [ "feedback" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
* Added 10 min timeout to the sbt steps in the two workflows
* Workflows only run for PRs to `main` for Dev Use and `feedback` for Studnet Assignment use.

Testing: 
sbt-test workflow ran and failed as expected. 
the autograding.yml workflow can't be tested as is due to secret related Github rules. 
I will trigger one post-merge, but changes are identical between the two. 